### PR TITLE
Olympian events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,8 @@
 class Event < ApplicationRecord
 
+  # relationships
+  has_many :olympian_events
+
   # validations
   validates :event, presence: true, uniqueness: true
   validates :sport, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,7 @@ class Event < ApplicationRecord
 
   # relationships
   has_many :olympian_events
+  has_many :olympians, through: :olympian_events
 
   # validations
   validates :event, presence: true, uniqueness: true

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -2,6 +2,7 @@ class Olympian < ApplicationRecord
 
   # relationships
   has_many :olympian_events
+  has_many :events, through: :olympian_events
 
   # validations
   validates :name, presence: true, uniqueness: true

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -1,4 +1,9 @@
 class Olympian < ApplicationRecord
+
+  # relationships
+  has_many :olympian_events
+
+  # validations
   validates :name, presence: true, uniqueness: true
   validates :sex, presence: true
   validates :age, presence: true, numericality: { only_integer: true }

--- a/app/models/olympian_event.rb
+++ b/app/models/olympian_event.rb
@@ -1,0 +1,12 @@
+class OlympianEvent < ApplicationRecord
+
+  # relationships
+  belongs_to :olympian
+  belongs_to :event
+
+  # validations
+  validates :olympian_id, presence: true
+  validates :event_id, presence: true
+  validates :medal, presence: true
+
+end

--- a/db/migrate/20190916031033_create_olympian_events.rb
+++ b/db/migrate/20190916031033_create_olympian_events.rb
@@ -1,0 +1,11 @@
+class CreateOlympianEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :olympian_events do |t|
+      t.references :olympian, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+      t.string :medal
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_020027) do
+ActiveRecord::Schema.define(version: 2019_09_16_031033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,16 @@ ActiveRecord::Schema.define(version: 2019_09_16_020027) do
     t.string "games"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "olympian_events", force: :cascade do |t|
+    t.bigint "olympian_id", null: false
+    t.bigint "event_id", null: false
+    t.string "medal"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_olympian_events_on_event_id"
+    t.index ["olympian_id"], name: "index_olympian_events_on_olympian_id"
   end
 
   create_table "olympians", force: :cascade do |t|
@@ -49,4 +59,6 @@ ActiveRecord::Schema.define(version: 2019_09_16_020027) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "olympian_events", "events"
+  add_foreign_key "olympian_events", "olympians"
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -22,10 +22,12 @@ namespace :import_csv do
             event_hash[key] = value
           end
         end
-        Olympian.create(olympian_hash)
-        Event.create(event_hash)
+        olympian = Olympian.find_or_create_by(olympian_hash)
+        event = Event.find_or_create_by(event_hash)
+        OlympianEvent.create(olympian_id: olympian.id, event_id: event.id, medal: hash["medal"])
       end
       puts "Added #{Olympian.count} olympians to the olympians table in the database."
       puts "Added #{Event.count} events to the events table in the database."
+      puts "Added #{OlympianEvent.count} olympian events to the olympian events table in the database."
     end
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -15,6 +15,7 @@ namespace :import_csv do
         hash = row.to_hash
         olympian_hash = {}
         event_hash = {}
+        
         hash.each_pair do |key, value|
           if Olympian.has_attribute?(key)
             olympian_hash[key] = value
@@ -22,6 +23,7 @@ namespace :import_csv do
             event_hash[key] = value
           end
         end
+
         olympian = Olympian.find_or_create_by(olympian_hash)
         event = Event.find_or_create_by(event_hash)
         OlympianEvent.create(olympian_id: olympian.id, event_id: event.id, medal: hash["medal"])

--- a/spec/factories/olympian_events.rb
+++ b/spec/factories/olympian_events.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :olympian_event do
+    olympian { nil }
+    event { nil }
+    medal { "MyString" }
+  end
+end

--- a/spec/factories/olympians.rb
+++ b/spec/factories/olympians.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :olympian do
-    name { "MyString" }
-    sex { "MyString" }
-    age { 1 }
-    height { 1 }
-    weight { 1 }
-    team { "MyString" }
+    sequence(:name) { |n| "Olympian #{n}" }
+    sex { ["M", "F"].sample }
+    sequence(:age) { |n|10 + n }
+    sequence(:height) { |n| 100 + n }
+    sequence(:weight) { |n| 100 + n }
+    team { ["GER", "USA", "RUS", "AUS", "POL"].sample }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -7,4 +7,8 @@ RSpec.describe Event, type: :model do
     it { should validate_presence_of :sport }
     it { should validate_presence_of :games }
   end
+
+  describe "relationships" do
+    it { should have_many :olympian_events }
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -10,5 +10,6 @@ RSpec.describe Event, type: :model do
 
   describe "relationships" do
     it { should have_many :olympian_events }
+    it { should have_many :olympians }
   end
 end

--- a/spec/models/olympian_event_spec.rb
+++ b/spec/models/olympian_event_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe OlympianEvent, type: :model do
+  describe "validations" do
+    it { should validate_presence_of :olympian_id }
+    it { should validate_presence_of :event_id }
+    it { should validate_presence_of :medal }
+  end
+end

--- a/spec/models/olympian_event_spec.rb
+++ b/spec/models/olympian_event_spec.rb
@@ -6,4 +6,9 @@ RSpec.describe OlympianEvent, type: :model do
     it { should validate_presence_of :event_id }
     it { should validate_presence_of :medal }
   end
+
+  describe "relationships" do
+    it { should belong_to :olympian }
+    it { should belong_to :event }
+  end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe Olympian, type: :model do
     it { should validate_presence_of :weight }
     it { should validate_presence_of :team }
   end
+
+  describe "relationships" do
+    it { should have_many :olympian_events }
+  end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -13,5 +13,6 @@ RSpec.describe Olympian, type: :model do
 
   describe "relationships" do
     it { should have_many :olympian_events }
+    it { should have_many :events }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,9 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  # Ability to use FactoryBot methods
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
## What does this PR do?
- [x] New feature
- [ ] Bug Fix

## Description of Implementation/Fix:
This PR adds the OlympianEvent model which belongs to both an Olympian and Event, and is a joins table between Olympians and Events which in turn have many-to-many relationships with each other and also each have many OlympianEvents.

## What did you struggle on?
Nothing really. The associations/relationships went smooth and using find_or_create_by in the rake task made it relatively easy to import OlympianEvents without doing anything else to the import_csv task.

## Did this break anything?
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Checklist:
- [x] Wrote Tests
- [ ] Implemented
- [ ] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code has no unused/commented out code
- [ ] My code runs locally

## Testing:
- Overall coverage: 98.57%
- Model coverage: 100%

## Testing Changes
- [x] New tests have been created
- [ ] No Tests have been changed
- [ ] Some Tests have been changed (describe which tests have been changed and why):
- [ ] All of the Tests have been changed (Please describe happened):
