### PR TITLE
Olympian stats

### DIFF
--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::OlympianStatsController < ApplicationController
+
+  def index
+    render json: OlympianStatsSerializer.serialize, status: :ok
+  end
+
+end

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -2,11 +2,11 @@ class Api::V1::OlympiansController < ApplicationController
 
   def index
     if olympian_params[:age] == nil
-      render json: OlympiansSerializer.new(Olympian.limit(25)).serialize
+      render json: OlympiansSerializer.new(Olympian.limit(25)).serialize, status: :ok
     elsif olympian_params[:age] == "youngest"
-      render json: OlympianSerializer.new(Olympian.youngest).serialize
+      render json: OlympianSerializer.new(Olympian.youngest).serialize, status: :ok
     elsif olympian_params[:age] == "oldest"
-      render json: OlympianSerializer.new(Olympian.oldest).serialize
+      render json: OlympianSerializer.new(Olympian.oldest).serialize, status: :ok
     end
   end
 

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -36,4 +36,8 @@ class Olympian < ApplicationRecord
     end
   end
 
+  def self.average_age
+    Olympian.average(:age)
+  end
+
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -26,11 +26,13 @@ class Olympian < ApplicationRecord
     Olympian.order(age: :desc).take
   end
 
-  def self.average_weight(sex)
+  def self.average_weight(sex = nil)
     if sex == "males"
       Olympian.where(sex: "M").average(:weight)
     elsif sex == "females"
       Olympian.where(sex: "F").average(:weight)
+    else
+      Olympian.average(:weight)
     end
   end
 

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -26,4 +26,12 @@ class Olympian < ApplicationRecord
     Olympian.order(age: :desc).take
   end
 
+  def self.average_weight(sex)
+    if sex == "males"
+      Olympian.where(sex: "M").average(:weight)
+    elsif sex == "females"
+      Olympian.where(sex: "F").average(:weight)
+    end
+  end
+
 end

--- a/app/serializers/olympian_stats_serializer.rb
+++ b/app/serializers/olympian_stats_serializer.rb
@@ -1,0 +1,16 @@
+class OlympianStatsSerializer
+
+  def self.serialize
+    output = { "olympian_stats": {}}
+    output[:olympian_stats][:total_competing_olympians] = Olympian.count
+    output[:olympian_stats][:average_weight] =
+      {
+        "unit": "kg",
+        "male_olympians": Olympian.average_weight("males"),
+        "female_olympians": Olympian.average_weight("females")
+      }
+    output[:olympian_stats][:average_age] = Olympian.average_age
+    output
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
+      get 'olympian_stats', to: 'olympian_stats#index'
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -80,5 +80,9 @@ RSpec.describe Olympian, type: :model do
       expect(Olympian.average_weight("females")).to eq(2)
       expect(Olympian.average_weight).to eq(3.5)
     end
+
+    it "returns the average age" do
+      expect(Olympian.average_age).to eq(3.5)
+    end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Olympian, type: :model do
     it "returns the average weight" do
       expect(Olympian.average_weight("males")).to eq(5)
       expect(Olympian.average_weight("females")).to eq(2)
+      expect(Olympian.average_weight).to eq(3.5)
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -59,11 +59,12 @@ RSpec.describe Olympian, type: :model do
 
   describe  "class methods" do
     before :each do
-      @olympian_1 = create(:olympian, age: 1)
-      @olympian_2 = create(:olympian, age: 2)
-      @olympian_3 = create(:olympian, age: 5)
-      @olympian_4 = create(:olympian, age: 1)
-      @olympian_5 = create(:olympian, age: 4)
+      @olympian_1 = create(:olympian, age: 1, weight: 1, sex: "F")
+      @olympian_2 = create(:olympian, age: 2, weight: 2, sex: "F")
+      @olympian_3 = create(:olympian, age: 3, weight: 3, sex: "F")
+      @olympian_4 = create(:olympian, age: 4, weight: 4, sex: "M")
+      @olympian_5 = create(:olympian, age: 5, weight: 5, sex: "M")
+      @olympian_6 = create(:olympian, age: 6, weight: 6, sex: "M")
     end
 
     it "returns the youngest olympian" do
@@ -71,8 +72,12 @@ RSpec.describe Olympian, type: :model do
     end
 
     it "returns the oldest olympian" do
-      expect(Olympian.oldest).to eq(@olympian_3)
+      expect(Olympian.oldest).to eq(@olympian_6)
+    end
+
+    it "returns the average weight" do
+      expect(Olympian.average_weight("males")).to eq(5)
+      expect(Olympian.average_weight("females")).to eq(2)
     end
   end
-
 end

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe "Olympians endpoints" do
+  before :each do
+    @olympian_1 = create(:olympian, age: 1, weight: 1, sex: "F")
+    @olympian_2 = create(:olympian, age: 2, weight: 2, sex: "F")
+    @olympian_3 = create(:olympian, age: 3, weight: 3, sex: "F")
+    @olympian_4 = create(:olympian, age: 4, weight: 4, sex: "M")
+    @olympian_5 = create(:olympian, age: 5, weight: 5, sex: "M")
+    @olympian_6 = create(:olympian, age: 6, weight: 6, sex: "M")
+
+    @event_1 = create(:event)
+    @event_2 = create(:event)
+    @event_3 = create(:event)
+
+    @olympian_event_1_1 = create(:olympian_event, olympian: @olympian_1, event: @event_1, medal: "Gold" )
+    @olympian_event_2_1 = create(:olympian_event, olympian: @olympian_2, event: @event_1, medal: "Silver" )
+    @olympian_event_3_1 = create(:olympian_event, olympian: @olympian_3, event: @event_1, medal: "Bronze" )
+    @olympian_event_4_1 = create(:olympian_event, olympian: @olympian_4, event: @event_1, medal: "NA" )
+    @olympian_event_5_1 = create(:olympian_event, olympian: @olympian_5, event: @event_1, medal: "NA" )
+    @olympian_event_6_1 = create(:olympian_event, olympian: @olympian_6, event: @event_1, medal: "NA" )
+
+    @olympian_event_1_2 = create(:olympian_event, olympian: @olympian_1, event: @event_2, medal: "NA" )
+    @olympian_event_2_2 = create(:olympian_event, olympian: @olympian_2, event: @event_2, medal: "Silver" )
+    @olympian_event_3_2 = create(:olympian_event, olympian: @olympian_3, event: @event_2, medal: "Bronze" )
+    @olympian_event_4_2 = create(:olympian_event, olympian: @olympian_4, event: @event_2, medal: "NA" )
+    @olympian_event_5_2 = create(:olympian_event, olympian: @olympian_5, event: @event_2, medal: "NA" )
+    @olympian_event_6_2 = create(:olympian_event, olympian: @olympian_6, event: @event_2, medal: "NA" )
+
+    @olympian_event_1_2 = create(:olympian_event, olympian: @olympian_1, event: @event_3, medal: "NA" )
+    @olympian_event_2_2 = create(:olympian_event, olympian: @olympian_2, event: @event_3, medal: "NA" )
+    @olympian_event_3_2 = create(:olympian_event, olympian: @olympian_3, event: @event_3, medal: "Bronze" )
+    @olympian_event_4_2 = create(:olympian_event, olympian: @olympian_4, event: @event_3, medal: "NA" )
+    @olympian_event_5_2 = create(:olympian_event, olympian: @olympian_5, event: @event_3, medal: "NA" )
+    @olympian_event_6_2 = create(:olympian_event, olympian: @olympian_6, event: @event_3, medal: "NA" )
+  end
+
+  it "returns aggregate olypmpian statistics" do
+    get "/api/v1/olympian_stats"
+
+    expect(response).to have_http_status(200)
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data.keys).to eq([:olympian_stats])
+    expect(data[:olympian_stats].keys).to eq([:total_competing_olympians, :average_weight, :average_age])
+  end
+
+end

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe "Olympians endpoints" do
+describe "olympian_stats endpoint" do
   before :each do
     @olympian_1 = create(:olympian, age: 1, weight: 1, sex: "F")
     @olympian_2 = create(:olympian, age: 2, weight: 2, sex: "F")

--- a/spec/requests/api/v1/olympians_request_spec.rb
+++ b/spec/requests/api/v1/olympians_request_spec.rb
@@ -57,12 +57,12 @@ describe "Olympians endpoints" do
   it "returns the youngest olympian" do
     get "/api/v1/olympians?age=oldest"
 
-  expect(response).to have_http_status(200)
-  data = JSON.parse(response.body, symbolize_names: true)
+    expect(response).to have_http_status(200)
+    data = JSON.parse(response.body, symbolize_names: true)
 
-  expect(data.keys).to eq([:olympian])
-  expect(data.count).to eq(1)
-  expect(data[:olympian].keys).to eq([:name, :team, :age, :sport, :total_medals_won])
-  expect(data[:olympian][:name]).to eq(@olympian_5.name)
+    expect(data.keys).to eq([:olympian])
+    expect(data.count).to eq(1)
+    expect(data[:olympian].keys).to eq([:name, :team, :age, :sport, :total_medals_won])
+    expect(data[:olympian][:name]).to eq(@olympian_5.name)
   end
 end


### PR DESCRIPTION
## What does this PR do?
- [x] New feature
- [ ] Bug Fix

## Description of Implementation/Fix:
This PR adds the `api/v1/olympian_stats` endpoint which receives a GET request and returns a JSON formatted object with aggregate statistics about the olympians.

## What did you struggle on?
Not JSON 1.0 compliant formatting so couldn't use fast_jsonapi (I suppose I could've chosen to against the client's formatting wishes, but didn't).

## Did this break anything?
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Checklist:
- [x] Wrote Tests
- [x] Implemented
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code has no unused/commented out code
- [x] My code runs locally

## Testing:
- Overall coverage: 100%
- Model coverage: 100%

## Testing Changes
- [x] New tests have been created
- [ ] No Tests have been changed
- [ ] Some Tests have been changed (describe which tests have been changed and why):
- [ ] All of the Tests have been changed (Please describe happened):
