### PR TITLE
Adds GET `api/v1/events` endpoint

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::EventsController < ApplicationController
+
+  def index
+    render json: EventsSerializer.new(Event.all).serialize_index, status: :ok
+  end
+
+end

--- a/app/serializers/events_serializer.rb
+++ b/app/serializers/events_serializer.rb
@@ -1,0 +1,23 @@
+ class EventsSerializer
+
+   def initialize(events)
+     @events = events
+   end
+
+   def serialize_index
+     output = { "events": [] }
+     @sports ||= @events.select(:sport).distinct.pluck(:sport)
+
+     @sports.each do |sport|
+       output[:events] <<
+        {
+          "sport": sport,
+          "events": Event.select(:event)
+                         .where(sport: sport)
+                         .pluck(:event)
+        }
+     end
+     output
+   end
+
+ end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      get '/olympians', to: 'olympians#index'
-      get 'olympian_stats', to: 'olympian_stats#index'
+      get '/olympians',      to: 'olympians#index'
+      get '/olympian_stats', to: 'olympian_stats#index'
+      get '/events',         to: 'events#index'
     end
   end
 end

--- a/spec/requests/api/v1/events_request_spec.rb
+++ b/spec/requests/api/v1/events_request_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "Events request endpoint" do
+  before :each do
+    @event_1 = create(:event, sport: "Archery")
+    @event_2 = create(:event, sport: "Badminton" )
+    @event_3 = create(:event, sport: "Badminton" )
+    @event_4 = create(:event, sport: "Archery" )
+    @event_5 = create(:event, sport: "Soccer" )
+    @event_6 = create(:event, sport: "Track" )
+  end
+
+  it "returns aggregate olypmpian statistics" do
+    get "/api/v1/events"
+
+    expect(response).to have_http_status(200)
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data.keys).to eq([:events])
+    expect(data[:events].count).to eq(4)
+    expect(data[:events].first.keys).to eq([:sport, :events])
+  end
+
+end


### PR DESCRIPTION
## What does this PR do?
- [x] New feature
- [ ] Bug Fix

## Description of Implementation/Fix:
This PR adds the `api/v1/events` endpoint which receives a GET request and returns a JSON formatted object with a key of events which points to each sport and the sport's accompanying events.

## What did you struggle on?
The format of the response object isn't what I would have picked (it's not JSON 1.0, it's a bit strange to have a key of "events" pointing to different "sports".

Also, I really don't like the number of calls that I'm making to the database on this and would rather have a normalized "sports" table which I could call and eager load the associated events (a sport would have many events and an event would belong to a sport). I may come back and refactor this later to remove some technical debt, but this does the thing atm.

## Did this break anything?
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Checklist:
- [x] Wrote Tests
- [x] Implemented
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code has no unused/commented out code
- [x] My code runs locally

## Testing:
- Overall coverage: 100%
- Model coverage: 100%

## Testing Changes
- [x] New tests have been created
- [ ] No Tests have been changed
- [ ] Some Tests have been changed (describe which tests have been changed and why):
- [ ] All of the Tests have been changed (Please describe happened):
